### PR TITLE
added methods ArduinoModule#d0, a0, a1 to read input pins

### DIFF
--- a/lib/little_bits/arduino_module.rb
+++ b/lib/little_bits/arduino_module.rb
@@ -4,10 +4,12 @@ module LittleBits
   class ArduinoModule
     def initialize(serial_port)
       @arduino = ArduinoFirmata.connect(serial_port)
+      @arduino.pin_mode 0, ArduinoFirmata::INPUT
 
       Kernel.at_exit { @arduino.close }
     end
 
+    ## output pins
     def d1(value)
       arduino.digital_write(1, value)
     end
@@ -26,6 +28,19 @@ module LittleBits
       else
         arduino.digital_write(9, value)
       end
+    end
+
+    ## input pins
+    def d0
+      arduino.digital_read 0
+    end
+
+    def a0
+      arduino.analog_read 0
+    end
+
+    def a1
+      arduino.analog_read 1
     end
 
     private


### PR DESCRIPTION
Hi, thank you for useful library.
I have added methods to read value from left-side modules of arduino-bit.
- arduino_module.d0
  - return `true` or `false`
- arudino_module.a0
- arudino_module.a1
  - return analog value `0~1023`
## usage

digital_read -> digital_write

``` ruby
require 'little_bits'
arduino_module = LittleBits::ArduinoModule.new '/dev/tty.usbmodem1421'

loop do
  stat = arduino_module.d0
  puts stat
  arduino_module.d1 stat
  sleep 0.1
end
```

analog_read -> analog_write

``` ruby
loop do
  an = arduino_module.a1
  puts an
  arduino_module.d9 an/4
  sleep 0.1
end
```
